### PR TITLE
link_to 修正

### DIFF
--- a/app/assets/stylesheets/items_new.scss
+++ b/app/assets/stylesheets/items_new.scss
@@ -11,6 +11,7 @@
       padding: 36px 16px;
       font-size: 22px;
       text-align: center;
+      font-weight: bold;
     }
     &__sell__inner__box{
       width: 620px;

--- a/app/views/shared/_header2.html.haml
+++ b/app/views/shared/_header2.html.haml
@@ -2,7 +2,8 @@
   .header-box
     .header-box__search
       .header-box__search__logo
-        = link_to image_tag "/images/SVG/fmarket_logo_red.svg", alt: "Mercari", width: "140"
+        = link_to root_path do
+          = image_tag "/images/SVG/fmarket_logo_red.svg", alt: "Mercari", width: "140"
       %form#form01{action: "search"}
         %input#input01{type: "search", name: "keyword", placeholder: "何かお探しですか？"}
           %button#submit01


### PR DESCRIPTION
# what
フリーマーケットのアイコンにlink_toでパスを指定
商品出品画面のフォント修正 
# why 
link_toでパスが指定されていなかったから
フォントがメルカリと違ったから